### PR TITLE
Added support for building on Apple Silicon.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ if (MSVC)
     )
 endif()
 
+# Build a single binary for both arm64 and x86_64 on macOS.
+# This also links the correct Library binaries for the SFML
+# and OpenAL dependencies.
+set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+
 # Turn on compile warnings
 target_compile_options(${PROJECT_NAME} PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ git submodule update
 
 Build Instructions
 
-Linux:
+Requires CMake.
+
+Linux and macOS:
+macOS requires Xcode or the Xcode command line tools. If you use homebrew, the command line tools are installed as part of initial setup.
 ```
 mkdir -p build
 cd build
@@ -27,8 +30,6 @@ cmake .. -DCMAKE_INSTALL_PREFIX=../install
 cmake --build . --config Release --parallel 6
 cmake --install .
 ```
-
-I don't own a Mac but I'm sure XCode can interpret CMake.
 
 Run from within the install directory so that the binary can find the assets.
 


### PR DESCRIPTION
* Bump SFML to a more recent commit where macOS ARM64 support was added.
* Set a CMake variable to build a unified arm64 and x86_64 binary.